### PR TITLE
add ability to double click a cookie to open the editing pane.

### DIFF
--- a/views/cookie.js
+++ b/views/cookie.js
@@ -5,7 +5,8 @@ ci.Views.Cookie = Backbone.View.extend({
   tagName: 'tr',
 
   events: {
-    'contextmenu' : '_onContextMenu'
+    'contextmenu' : '_onContextMenu',
+    'dblclick' : '_onDblClick'
   },
 
   initialize: function() {
@@ -35,6 +36,15 @@ ci.Views.Cookie = Backbone.View.extend({
     view.$el.focus();
     event.stopPropagation();
     event.preventDefault();
+  },
+
+  _onDblClick: function(event) {
+    event.preventDefault();
+
+    if (ci.editor) { ci.editor.remove(); }
+    ci.editor = new ci.Views.CookieForm({ model: this.model });
+    $(document.body).append(ci.editor.render().el);
+    ci.editor.$('input').eq(0).focus();
   }
 
 });


### PR DESCRIPTION
This is a quick way to open the cookie editor for a specific cookie by just double clicking it.
