### PR TITLE
Narrow down manifest permissions.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,6 @@
    "manifest_version": 2,
    "minimum_chrome_version": "19.0",
    "name": "Cookie Inspector",
-   "permissions": [ "cookies", "*://*/", "tabs", "unlimitedStorage", "webNavigation", "http://*/*", "https://*/*" ],
+   "permissions": [ "cookies" ],
    "version": "2.0.4"
 }


### PR DESCRIPTION
Hello,

when installing the extensions it asks for a lot of permissions, like all browsing data of every website.
This is way too much for an extension which purpose is to browse and edit cookies.

Hence I reduced the permissions to `cookies` only.

:thumbsup: 
