### PR TITLE
Dark theme support

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -48,7 +48,9 @@ table {
 }
 
 .darkTheme #header table th {
-    color: #333;
+    background: #242424;
+    color: #C0C9D3;
+    border-color: #3E3E3E;
 }
 
 #header table th.desc div {
@@ -67,8 +69,12 @@ table {
   background: #FFF;
 }
 
+.darkTheme #header table th:hover {
+  background: #303030;
+}
+
 .darkTheme #header table th:active {
-  background: #444;
+  background: #4F4F4F;
 }
 
 #header table th.corner {
@@ -102,6 +108,10 @@ table {
   -webkit-background-size: 1px 46px;
 }
 
+.darkTheme #content table {
+    background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), color-stop(0.5, rgba(0, 0, 0, 0)), color-stop(0.5, rgba(255, 255, 255, 0.025)), to(rgba(255, 255, 255, 0.025)));
+}
+
 #content table td {
   border-right: 1px solid rgb(179, 179, 179);
   border-spacing: 0;
@@ -111,7 +121,8 @@ table {
 }
 
 .darkTheme #content table td {
-    color: #DDD;
+    color: #C0C9D3;
+    border-color: #3E3E3E;
 }
 
 #content table td div {
@@ -145,7 +156,7 @@ table {
 }
 
 .darkTheme #content table tr.cookie-row:hover {
-  background: #444;
+  background: #482F0B;
 }
 
 #content table tr.filler td {
@@ -196,6 +207,12 @@ table {
   box-shadow: -1px 0 3px rgba(0,0,0,0.08);
   overflow-x: hidden;
   overflow-y: scroll;
+}
+
+.darkTheme #cookie-form-view {
+    background: #2A2A2A;
+    color: #C0C9D3;
+    border-color: #5E5E5E;
 }
 
 #cookie-form-view-header {

--- a/css/core.css
+++ b/css/core.css
@@ -47,6 +47,10 @@ table {
   -webkit-user-select: none;
 }
 
+.darkTheme #header table th {
+    color: #333;
+}
+
 #header table th.desc div {
   background-image: url(/images/tree_up.png);
   background-repeat: no-repeat;
@@ -61,6 +65,10 @@ table {
 
 #header table th:active {
   background: #FFF;
+}
+
+.darkTheme #header table th:active {
+  background: #444;
 }
 
 #header table th.corner {
@@ -102,6 +110,10 @@ table {
   padding: 1px 4px;
 }
 
+.darkTheme #content table td {
+    color: #DDD;
+}
+
 #content table td div {
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -130,6 +142,10 @@ table {
 
 #content table tr.cookie-row:hover {
   background: #E3E3E3;
+}
+
+.darkTheme #content table tr.cookie-row:hover {
+  background: #444;
 }
 
 #content table tr.filler td {

--- a/devtools-page.js
+++ b/devtools-page.js
@@ -1,7 +1,15 @@
 (function() {
 
-  chrome.devtools.panels.create('Cookies',
-                                'cookie-icon.png',
-                                'CookieInspectorChromium.html');
+    chrome.devtools.panels.create('Cookies',
+        'cookie-icon.png',
+        'CookieInspectorChromium.html',
+
+        function (panel) {
+            const themeColor = chrome.devtools.panels.themeName;
+
+            panel.onShown.addListener(function (panelWindow) {
+                panelWindow.document.body.classList.add(`${themeColor}Theme`);
+            });
+        });
 
 })();


### PR DESCRIPTION
### Changelog: 

1. A panel `onShown` listener.
2. A *class* assignment of either `defaultTheme` or `darkTheme` to the panel *body* based on the current devtools theme (**i.e.** `chrome.devtools.panels.themeName`).
3. Additional *css* rule-sets based for the `dark` theme.

![image](https://cloud.githubusercontent.com/assets/9957358/23142520/3ea541de-f771-11e6-9d4f-3b9f2e67bfc7.png)
